### PR TITLE
Completing NSOperation before executing callback

### DIFF
--- a/Source/AFHTTPSessionOperation.m
+++ b/Source/AFHTTPSessionOperation.m
@@ -42,15 +42,15 @@
     AFHTTPSessionOperation *operation = [[self alloc] init];
     
     NSURLSessionTask *task = [manager dataTaskWithHTTPMethod:method URLString:URLString parameters:parameters uploadProgress:uploadProgress downloadProgress:downloadProgress success:^(NSURLSessionDataTask *task, id responseObject){
+        [operation completeOperation];
         if (success) {
             success(task, responseObject);
         }
-        [operation completeOperation];
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        [operation completeOperation];
         if (failure) {
             failure(task, error);
         }
-        [operation completeOperation];
     }];
 
     operation.task = task;


### PR DESCRIPTION
I've just updated an old project from AFNetworking 1.x to 3.1, and found your wrapper very useful.

Maybe this change seems a little pedantic, but it solves an issue I had where I inspect the number of operations in the queue in the success callback. With AFNetworking 1.x code, the operation would have been removed from the queue before the callback, meaning I could see if the queue was empty. This change fixes the issue.
